### PR TITLE
Extract token

### DIFF
--- a/eve_auth_jwt/__init__.py
+++ b/eve_auth_jwt/__init__.py
@@ -1,2 +1,2 @@
 from .auth import JWTAuth, requires_token
-from .token import extract_token
+from .token import extract_token, verify_token

--- a/eve_auth_jwt/__init__.py
+++ b/eve_auth_jwt/__init__.py
@@ -1,2 +1,2 @@
 from .auth import JWTAuth, requires_token
-from .token import extract_token, verify_token
+from .token import extract_token, decode_token, verify_token

--- a/eve_auth_jwt/__init__.py
+++ b/eve_auth_jwt/__init__.py
@@ -1,1 +1,2 @@
-from .auth import JWTAuth, extract_token, requires_token
+from .auth import JWTAuth, requires_token
+from .token import extract_token

--- a/eve_auth_jwt/__init__.py
+++ b/eve_auth_jwt/__init__.py
@@ -1,1 +1,1 @@
-from .auth import JWTAuth, requires_token
+from .auth import JWTAuth, extract_token, requires_token

--- a/eve_auth_jwt/auth.py
+++ b/eve_auth_jwt/auth.py
@@ -5,7 +5,7 @@ from eve.utils import config
 from flask import request, Response, g
 from flask import abort
 from functools import wraps
-from .verify_token import verify_token
+from .token import extract_token, verify_token
 
 
 class JWTAuth(BasicAuth):
@@ -86,26 +86,6 @@ class JWTAuth(BasicAuth):
         self.set_request_auth_value(account_id)
 
         return True
-
-
-def extract_token():
-    """
-    Parse access token from incoming request.
-
-    Returns: (access_token, isParam)
-        access_token (string or None): Access token
-        isParam (boolean): Whether token was parsed from URL parameters or from the request header
-    """
-    if request.args.get('access_token'):
-        return (request.args.get('access_token'), True)
-
-    try:
-        access_token = request.headers.get('Authorization').split(' ')[1]
-        if access_token:
-            return (access_token, False)
-    except:
-        pass
-    return (None, False)
 
 
 def requires_token(audiences=[], allowed_roles=[]):

--- a/eve_auth_jwt/token.py
+++ b/eve_auth_jwt/token.py
@@ -1,4 +1,5 @@
 from eve.utils import config
+from flask import request
 import jwt
 
 
@@ -40,3 +41,23 @@ def verify_token(token, method=None, audiences=[], allowed_roles=[]):
             return (False, payload, account_id, roles)
 
     return (True, payload, account_id, roles)
+
+
+def extract_token():
+    """
+    Parse access token from incoming request.
+
+    Returns: (access_token, isParam)
+        access_token (string or None): Access token
+        isParam (boolean): Whether token was parsed from URL parameters or from the request header
+    """
+    if request.args.get('access_token'):
+        return (request.args.get('access_token'), True)
+
+    try:
+        access_token = request.headers.get('Authorization').split(' ')[1]
+        if access_token:
+            return (access_token, False)
+    except:
+        pass
+    return (None, False)

--- a/eve_auth_jwt/token.py
+++ b/eve_auth_jwt/token.py
@@ -3,17 +3,22 @@ from flask import request
 import jwt
 
 
-def verify_token(token, method=None, audiences=[], allowed_roles=[]):
+def decode_token(token, audiences=[]):
     # Try to decode token with each allowed audience
     for audience in audiences:
         try:
-            payload = jwt.decode(token, key=config.JWT_SECRET, issuer=config.JWT_ISSUER, audience=audience)
-            break  # this skips the for/else clause
+            return jwt.decode(token, key=config.JWT_SECRET, issuer=config.JWT_ISSUER, audience=audience)
         except jwt.InvalidAudienceError:
             continue
         except Exception:
-            return (False, None, None, None)
+            return None
     else:
+        return None
+
+
+def verify_token(token, method=None, audiences=[], allowed_roles=[]):
+    payload = decode_token(token, audiences)
+    if payload is None:
         return (False, None, None, None)
 
     # Get account id


### PR DESCRIPTION
Eve cannot store the parsed token payload inside a request, so the token/payload extraction functions need to be exposed to rerun extraction at the route level.