### PR TITLE
Allow JWT_AUDIENCES and sub JWT claim to be optional.

### DIFF
--- a/eve_auth_jwt/auth.py
+++ b/eve_auth_jwt/auth.py
@@ -43,7 +43,7 @@ class JWTAuth(BasicAuth):
             try:
                 access_token = request.headers.get('Authorization').split(' ')[1]
                 authorized = self.check_token(access_token, allowed_roles, resource, method)
-            except:
+            except Exception:
                 pass
 
         return authorized

--- a/test.py
+++ b/test.py
@@ -10,7 +10,6 @@ from eve_auth_jwt.tests import test_routes
 settings = {
     'JWT_SECRET': 'secret',
     'JWT_ISSUER': 'https://domain.com/token',
-    'JWT_AUDIENCES': ['aud1'],
     'JWT_ROLES_CLAIM': 'roles',
     'JWT_SCOPE_CLAIM': 'scope',
     'DOMAIN': {
@@ -18,13 +17,17 @@ settings = {
             'schema': {
                 'name': {},
             },
+            'audiences': ['aud1'],
             'resource_methods': ['POST', 'GET'],
         },
         'bar': {
             'audiences': ['aud2'],
         },
         'baz': {
+            'audiences': ['aud1'],
             'allowed_roles': ['role1', 'role2'],
+        },
+        'bad': {
         },
     },
 }
@@ -86,7 +89,7 @@ class TestBase(unittest.TestCase):
                   'aud': 'aud1'}
         token = jwt.encode(claims, 'secret')
         r = self.test_client.get('/foo?access_token={}'.format(token.decode('utf-8')))
-        self.assertEqual(r.status_code, 401)
+        self.assertEqual(r.status_code, 200)
 
     def test_invalid_token_issuer(self):
         claims = {'iss': 'https://invalid-domain.com/token',
@@ -213,6 +216,21 @@ class TestBase(unittest.TestCase):
         token = jwt.encode(claims, 'secret')
         r = self.test_client.get('/token/failure?access_token={}'.format(token.decode('utf-8')))
         self.assertEqual(r.status_code, 401, r.data)
+
+    def test_no_audience_token_success(self):
+        claims = {'iss': 'https://domain.com/token'}
+        token = jwt.encode(claims, 'secret')
+        r = self.test_client.get('/bad?access_token={}'.format(token.decode('utf-8')))
+        self.assertEqual(r.status_code, 200)
+
+    def test_no_audience_token_failure(self):
+        claims = {'iss': 'https://domain.com/token',
+                  'aud': 'aud1',
+                  'sub': '0123456789abcdef01234567'}
+        token = jwt.encode(claims, 'secret')
+        r = self.test_client.get('/bad?access_token={}'.format(token.decode('utf-8')))
+        self.assertEqual(r.status_code, 401)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The documentation in README claims that JWT_AUDIENCES are optional:

> JWT_AUDIENCES:
> Defines a list of accepted audiences (aud claim). If not provided, only tokens with no audience set will be accepted. The resource level audiences parameter is also available.

But with the current implementation one must provide both audiences and the "sub" JWT claim.

This pull request makes JWT_AUDIENCES/audiences optional, and removes the validation that "sub" is provided.

Also adds two tests that would fail on previous versions.