### PR TITLE
Upgrade dependencies and test on python3.6 with travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
 - '2.7'
-- '3.3'
+- '3.6'
 - pypy
 services: mongodb
 script: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
     keywords=['eve', 'api', 'rest', 'oauth', 'auth', 'jwt'],
     packages=['eve_auth_jwt'],
     package_dir={'eve_auth_jwt': 'eve_auth_jwt'},
-    install_requires=['eve>=0.5.0', 'pyjwt==1.3.0'],
+    install_requires=['eve>=0.7.5', 'pyjwt==1.5.3'],
     test_suite='test',
-    tests_require=['flake8', 'nose'],
+    tests_require=['flake8'],
     license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Current builds on python3.3 fails because to old version of setuptools are installed.

Perhaps just upgrading to python3.6 and the dependencies might fix it.

Nose wasn't used for tests anymore, as far as I can see.

Signed-off-by: Even Thomassen <even.thomassen@noriginmedia.com>