### PR TITLE
Auth header

### DIFF
--- a/eve_auth_jwt/auth.py
+++ b/eve_auth_jwt/auth.py
@@ -36,15 +36,12 @@ class JWTAuth(BasicAuth):
             auth = request.authorization
             authorized = self.check_auth(auth.username, auth.password,
                                          allowed_roles, resource, method)
-        elif request.args.get('access_token'):
-            access_token = request.args.get('access_token')
-            authorized = self.check_token(access_token, allowed_roles, resource, method)
         else:
             try:
-                access_token = request.headers.get('Authorization').split(' ')[1]
-                authorized = self.check_token(access_token, allowed_roles, resource, method)
-            except:
-                pass
+                access_token = request.args['access_token']
+            except KeyError:
+                access_token = request.headers.get('Authorization', '').partition(' ')[2]
+            authorized = self.check_token(access_token, allowed_roles, resource, method)
 
         return authorized
 
@@ -158,11 +155,15 @@ def get_request_auth_value():
     return g.get(AUTH_VALUE)
 
 
-def requires_token(audiences=[], allowed_roles=[]):
+def requires_token(audiences=None, allowed_roles=None):
     def requires_token_wrapper(f):
         @wraps(f)
         def decorated(*args, **kwargs):
-            token = request.args.get('access_token')
+            try:
+                token = request.args['access_token']
+            except KeyError:
+                token = request.headers.get('Authorization', '').partition(' ')[2]
+
             verified, payload, account_id, roles = verify_token(token, request.method, audiences, allowed_roles)
             if not verified:
                 abort(401)

--- a/test.py
+++ b/test.py
@@ -214,5 +214,21 @@ class TestBase(unittest.TestCase):
         r = self.test_client.get('/token/failure?access_token={}'.format(token.decode('utf-8')))
         self.assertEqual(r.status_code, 401, r.data)
 
+    def test_auth_header_token_success(self):
+        claims = {'iss': 'https://domain.com/token',
+                  'aud': 'aud1',
+                  'sub': '0123456789abcdef01234567',
+                  'roles': ['super'],
+                  'scope': 'user'}
+        token = jwt.encode(claims, 'secret')
+        headers = {'Authorization': 'Bearer {}'.format(token.decode('utf-8'))}
+        r = self.test_client.get('/token/success', headers=headers)
+        self.assertEqual(r.status_code, 200)
+
+    def test_auth_header_token_failure(self):
+        r = self.test_client.get('/token/failure')
+        self.assertEqual(r.status_code, 401, r.data)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The requires_token decorator should also accept token validation with the authorization header.

Adds the same functionality that #8 intended to, but that one hasn't been completed or updated in two weeks.

This one also adds tests that covers it.