### PR TITLE
Allow JWTAuth to be given a custom secret key and issuer values.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,28 @@ Example of access the parse JWT token fields::
         roles = get_authen_roles()
 
 
+Different JWTAuth on different endpoints
+----------------------------------------
+
+Eve supports both global authentication of the whole API, and endpoint-level authentication. If one wish to use different secret keys and/or issuers on certain endpoints, it is possible to create instances of JWTAuth which overrides the global config values of ``JWT_SECRET`` and ``JWT_ISSUER``.
+
+The secret key and issuer can be set through the JWTAuth constructor or as properties on instances of JWTAuth.
+
+Example usage::
+
+    from eve import Eve
+    from eve_auth_jwt import JWTAuth
+
+    second_auth = JWTAuth('custom secret', 'specific issuer')
+
+    app = Eve(auth=JWTAuth, settings=SETTINGS)
+
+    @app.route('/second')
+    @second_auth.requires_token()
+    def different_secret():
+        return 'Success with custom secret!'
+
+
 Licenses
 --------
 

--- a/eve_auth_jwt/tests/test_routes.py
+++ b/eve_auth_jwt/tests/test_routes.py
@@ -1,4 +1,5 @@
 from eve_auth_jwt import requires_token
+from eve_auth_jwt.auth import JWTAuth
 
 
 def register(app):
@@ -11,3 +12,11 @@ def register(app):
     @requires_token(audiences=['aud1'], allowed_roles=['super'])
     def requires_token_failure():
         return 'should not authenticate'
+
+    custom_auth = JWTAuth('custom_secret')
+    custom_auth.issuer = 'custom_issuer'
+
+    @app.route('/custom/success')
+    @custom_auth.requires_token(audiences=['aud1'], allowed_roles=['super'])
+    def requires_token_success2():
+        return 'true'

--- a/eve_auth_jwt/verify_token.py
+++ b/eve_auth_jwt/verify_token.py
@@ -2,12 +2,10 @@ from eve.utils import config
 import jwt
 
 
-def verify_token(token, method=None, audiences=None, allowed_roles=None):
+def verify_token(token, secret, issuer, method=None, audiences=None, allowed_roles=None):
     # Try to decode token with each allowed audience
     def decode(audience=None):
-        return jwt.decode(
-                token, key=config.JWT_SECRET,
-                issuer=config.JWT_ISSUER, audience=audience)
+        return jwt.decode(token, key=secret, issuer=issuer, audience=audience)
 
     if not audiences:
         try:


### PR DESCRIPTION
This makes it possible to use different issuer and/or secret keys
for different endpoints.

Should be completely backwards-compatible. If a secret or issuer
is not specified, it will use config values JWT_SECRET and
JWT_ISSUER as before, and the requires_token decorator is now
available also on the JWTAuth instance.

Additionally added tests for this new use cases.

Signed-off-by: Even Thomassen <even.thomassen@noriginmedia.com>