### PR TITLE
FIX: JWTAuth.check_token wont trigger a KeyError on resourceless endpoints

### DIFF
--- a/eve_auth_jwt/auth.py
+++ b/eve_auth_jwt/auth.py
@@ -101,7 +101,7 @@ class JWTAuth(BasicAuth):
         If the validation succeed, the claims are stored and accessible thru the
         get_authen_claims() method.
         """
-        resource_conf = config.DOMAIN[resource]
+        resource_conf = config.DOMAIN.get(resource, {})
         audiences = resource_conf.get('audiences', config.JWT_AUDIENCES)
         return self._perform_verification(token, audiences, allowed_roles)
 


### PR DESCRIPTION
That's a trivial fix that allow us to reach `home` route, and I guess other custom endpoints.