### PR TITLE
Return the correct headers for authenticate()

### DIFF
--- a/eve_auth_jwt/auth.py
+++ b/eve_auth_jwt/auth.py
@@ -78,8 +78,11 @@ class JWTAuth(BasicAuth):
             realm = 'Bearer realm="%s", error="invalid_token"' % __package__
         else:
             realm = 'Bearer realm="%s"' % __package__
-        resp = Response(None, 401, {'WWW-Authenticate': realm})
-        abort(401, description='Please provide proper credentials', response=resp)
+        abort(
+            401,
+            'Please provide proper credentials',
+            www_authenticate=('WWW-Authenticate', realm),
+        )
 
     def check_token(self, token, allowed_roles, resource, method):
         """


### PR DESCRIPTION
The call to abort seems to use wrong parameters. This new call
returns the proper headers for authenticate()
Fixes rs/eve-auth-jwt#19